### PR TITLE
Add automated API tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "start": "node server.js"
   },
   "keywords": [],

--- a/server.js
+++ b/server.js
@@ -450,6 +450,10 @@ const server = http.createServer((req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-server.listen(PORT, () => {
-  console.log(`Location chat server running on http://localhost:${PORT}`);
-});
+if (require.main === module) {
+  server.listen(PORT, () => {
+    console.log(`Location chat server running on http://localhost:${PORT}`);
+  });
+}
+
+module.exports = server;

--- a/style.css
+++ b/style.css
@@ -46,6 +46,10 @@ main {
   display: flex;
   flex-direction: column;
   border-top: 1px solid #ddd;
+  /* Ensure the chat panel sits above the map and provides a positioning
+     context for sticky children such as the input area. */
+  position: relative;
+  z-index: 1;
 }
 
 #messages {
@@ -104,6 +108,10 @@ main {
   padding: 8px;
   background-color: #eee;
   border-top: 1px solid #ddd;
+  /* Anchor the input area to the bottom of the chat panel so that it does
+     not overlap the map or messages when the layout changes. */
+  position: sticky;
+  bottom: 0;
 }
 
 #message-input {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,121 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const server = require('../server');
+
+let listener;
+let port;
+
+test.before(async () => {
+  await new Promise((resolve) => {
+    listener = server.listen(0, () => {
+      port = listener.address().port;
+      resolve();
+    });
+  });
+});
+
+test.after(() => new Promise((resolve) => listener.close(resolve)));
+
+test('message and location endpoints', async () => {
+  const base = `http://localhost:${port}`;
+  let res = await fetch(`${base}/message?room=room1&password=pass&name=Bob&text=Hi`);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), 'ok');
+
+  res = await fetch(`${base}/location?room=room1&password=pass&name=Bob&lat=1&lon=2`);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), 'ok');
+});
+
+test('invite flow limits usage', async () => {
+  const base = `http://localhost:${port}`;
+  await fetch(`${base}/message?room=room2&password=pass&name=Alice&text=Hi`);
+
+  const inviteRes = await fetch(`${base}/invite/create?room=room2&password=pass&expiry=1&maxUses=2`);
+  assert.equal(inviteRes.status, 200);
+  const { token } = await inviteRes.json();
+
+  let res = await fetch(`${base}/invite?token=${token}`);
+  assert.equal(res.status, 200);
+
+  res = await fetch(`${base}/invite?token=${token}`);
+  assert.equal(res.status, 200);
+
+  res = await fetch(`${base}/invite?token=${token}`);
+  assert.equal(res.status, 404);
+});
+
+test('deleteRoom removes room', async () => {
+  const base = `http://localhost:${port}`;
+  await fetch(`${base}/message?room=room3&password=pass&name=Alice&text=Hi`);
+
+  let res = await fetch(`${base}/deleteRoom?room=room3&password=pass`);
+  assert.equal(res.status, 200);
+  assert.equal(await res.text(), 'deleted');
+
+  res = await fetch(`${base}/checkRoom?room=room3&password=pass`);
+  assert.equal(res.status, 404);
+});
+
+test('SSE streams history and logout broadcasts removal', async () => {
+  const base = `http://localhost:${port}`;
+  // Preload history then connect to SSE and verify it is delivered
+  await fetch(`${base}/message?room=sse&password=pass&name=Bob&text=Hello`);
+  await fetch(`${base}/location?room=sse&password=pass&name=Bob&lat=1&lon=2`);
+
+  const controller = new AbortController();
+  const res = await fetch(`${base}/events?room=sse&password=pass`, { signal: controller.signal });
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  while (!buf.includes('event: location')) {
+    const { done, value } = await reader.read();
+    assert.ok(!done, 'stream ended before delivering history');
+    buf += dec.decode(value);
+  }
+  assert.match(buf, /event: message\ndata:.*"text":"Hello"/);
+  assert.match(buf, /event: location\ndata:.*"lat":1/);
+
+  // Now test live broadcast and logout removal
+  buf = '';
+  await fetch(`${base}/location`, {
+    method: 'POST',
+    body: JSON.stringify({ room: 'sse', password: 'pass', name: 'Bob', lat: 3, lon: 4 })
+  });
+  while (!buf.includes('event: location')) {
+    const { done, value } = await reader.read();
+    assert.ok(!done, 'stream ended before location broadcast');
+    buf += dec.decode(value);
+  }
+  assert.match(buf, /event: location\ndata:.*"lat":3/);
+
+  buf = '';
+  await fetch(`${base}/logout?room=sse&password=pass&name=Bob`);
+  while (!buf.includes('event: remove')) {
+    const { done, value } = await reader.read();
+    assert.ok(!done, 'stream ended before remove broadcast');
+    buf += dec.decode(value);
+  }
+  assert.match(buf, /event: remove\ndata:.*"name":"Bob"/);
+  controller.abort();
+});
+
+test('rooms listing and password checks', async () => {
+  const base = `http://localhost:${port}`;
+  await fetch(`${base}/message?room=listRoom&password=secret&name=Bob&text=Hi`);
+
+  let res = await fetch(`${base}/rooms`);
+  assert.equal(res.status, 200);
+  const rooms = await res.json();
+  assert.ok(rooms.includes('listRoom'));
+
+  res = await fetch(`${base}/checkRoom?room=listRoom&password=secret`);
+  assert.equal(res.status, 200);
+
+  res = await fetch(`${base}/checkRoom?room=listRoom&password=wrong`);
+  assert.equal(res.status, 403);
+
+  res = await fetch(`${base}/checkRoom?room=doesNotExist&password=whatever`);
+  assert.equal(res.status, 404);
+});
+


### PR DESCRIPTION
## Summary
- export server and only listen when run directly
- add node:test based suite covering message, location, invite, delete, SSE, logout, room listing and password checks
- configure npm test to run the new tests
- anchor chat input area to the bottom to avoid overlapping the map

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2de64b3bc832e9e7908dcf6a5fbdf